### PR TITLE
Check for empty lines after clipping

### DIFF
--- a/R/isolines-grob.R
+++ b/R/isolines-grob.R
@@ -195,6 +195,9 @@ makeContent.isolines_grob <- function(x) {
       return(NULL)
     }
     clipped <- clip_lines(data$x, data$y, data$id, clip_boxes, asp = asp)
+    if (length(clipped$x) == 0) {
+      return(NULL)
+    }
     polylineGrob(
       clipped$x, clipped$y, clipped$id,
       default.units = x$units,


### PR DESCRIPTION
Fixes #21. I think this is straightforward since you already check this in the same way before clipping.

I don't see a place where this was tested but would be happy to add a test if you can think of a good way to do it!

``` r
library(isoband)
library(grid)

m <- matrix(c(0, 0, 0, 0, 0, 0,
              0, 0, 0, 1, 1, 0,
              0, 0, 1, 1, 1, 0,
              0, 1, 1, 0, 0, 0,
              0, 0, 0, 1, 0, 0,
              0, 0, 0, 0, 0, 0), 6, 6, byrow = TRUE)

df_lines <- isolines((1:ncol(m))/(ncol(m)+1), (nrow(m):1)/(nrow(m)+1), m, 0.5)
grob_lines <- isolines_grob(
  df_lines,
  gpar(fontsize = 1000),
  label_placer = label_placer_manual("0.5", 0.5, 0.5, 0)
)

grid.newpage()
grid.draw(grob_lines)
```

![](https://i.imgur.com/yWPqg9q.png)

<sup>Created on 2021-05-03 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>
