### PR TITLE
Corrects label angle for current aspect ratio

### DIFF
--- a/R/isolines-grob.R
+++ b/R/isolines-grob.R
@@ -163,7 +163,8 @@ makeContent.isolines_grob <- function(x) {
   # need to correct angle for current aspect ratio
   Sy <- convertHeight(unit(1, "npc"), "mm", valueOnly = TRUE)
   Sx <- convertWidth(unit(1, "npc"), "mm", valueOnly = TRUE)
-  labels_data$theta <- atan(tan(labels_data$theta)*Sy/Sx)
+  theta <- atan(tan(labels_data$theta)*Sy/Sx)
+  labels_data$theta <- ifelse(is.finite(theta), theta, 0)
 
   # calculate label widths and heights in npc units
   label_widths <- convertWidth(stringWidth(labels_data$label), x$units, valueOnly = TRUE)

--- a/R/isolines-grob.R
+++ b/R/isolines-grob.R
@@ -160,6 +160,11 @@ makeContent.isolines_grob <- function(x) {
     return(isolines_grob_makeContent_nolabels(x))
   }
 
+  # need to correct angle for current aspect ratio
+  Sy <- convertHeight(unit(1, "npc"), "mm", valueOnly = TRUE)
+  Sx <- convertWidth(unit(1, "npc"), "mm", valueOnly = TRUE)
+  labels_data$theta <- atan(tan(labels_data$theta)*Sy/Sx)
+
   # calculate label widths and heights in npc units
   label_widths <- convertWidth(stringWidth(labels_data$label), x$units, valueOnly = TRUE)
   label_heights <- convertHeight(


### PR DESCRIPTION
This PR addresses #27 by correcting the label angle at draw time to compensate by the viewport aspect ratio. 

Example code:

```r
library(isoband)
library(grid)

x <- (0:(ncol(volcano) - 1))/(ncol(volcano) - 1)
y <- ((nrow(volcano) - 1):0)/(nrow(volcano) - 1)
lines <- isolines(x, y, volcano, 5*(19:38))


g <- isolines_grob(
  lines, breaks = 20*(5:10),
  label_placer = label_placer_middle(),
  gp = gpar(
    fontsize = 10,
    lwd = c(1, 2, 1, 1),
    col = c("grey50", "grey20", "grey50", "grey50")
  )
)

grid.newpage()
grid.draw(g)
```

With current master branch. Notice the lower-right "100", for example: 

![](https://i.imgur.com/bUnyitx.png)

Exaggerated version:

![](https://i.imgur.com/1ddipn3.png)

WIth this PR:

![](https://i.imgur.com/ZtQOaLw.png)

Exaggerated version:

![](https://i.imgur.com/bkqVk7j.png)

